### PR TITLE
Add SQLite backend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -205,3 +205,4 @@ cython_debug/
 marimo/_static/
 marimo/_lsp/
 __marimo__/
+travel_app.db

--- a/README.md
+++ b/README.md
@@ -1,2 +1,6 @@
 # worker-travel-app
-A web app to digitize the WSIB Worker Travel &amp; Expense Form (2721A), letting injured workers submit mileage, transit, parking, and meal claims online. Includes auto-calculated mileage, receipt uploads, and digital signature. Future updates will include Google Maps route validation.
+A web app to digitize the WSIB Worker Travel &amp; Expense Form (2721A), letting injured workers submit mileage, transit, parking, and meal claims online. Includes auto-calculated mileage, receipt uploads, and digital signature.
+
+## Storage
+
+Submitted claims are persisted to `travel_app.db` using SQLite. Each submission is stored in a `submissions` table and each travel row in a `travel_entries` table referencing its parent submission. JSON and CSV copies are still written to the `submissions/` folder for easy export.


### PR DESCRIPTION
## Summary
- setup a new SQLite backend to store claims and travel entries
- document storage in README
- ignore generated database files

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_6871ef67bac08331bdfc67332c679b91