### PR TITLE
Fix curly apostrophe in deleteRow comment

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -291,7 +291,7 @@ function deleteRow(btn) {
     const row = btn.closest(".travel-row");
     const table = document.getElementById("travel-rows");
 
-    // Don’t delete the last remaining row
+    // Don't delete the last remaining row
     if (table.querySelectorAll(".travel-row").length === 1) {
         alert("At least one row must remain.");
         return;


### PR DESCRIPTION
## Summary
- replace curly apostrophe with ASCII in deleteRow guard

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6871e1b1fd1c8331837b9a0ba2b2be85